### PR TITLE
fix: updating only deleted_at on delete/undelete methods

### DIFF
--- a/drf_kit/models/soft_delete_models.py
+++ b/drf_kit/models/soft_delete_models.py
@@ -50,7 +50,7 @@ class SoftDeleteModelMixin(models.Model):
             from drf_kit.signals import UnplugSignal  # pylint: disable=import-outside-toplevel
 
             with UnplugSignal(signal=pre_save, func=verify_soft_deletion, model=self.__class__):
-                self.save()
+                self.save(update_fields=["deleted_at"])
 
             signals.post_soft_delete.send(sender=self.__class__, instance=self)
 
@@ -93,7 +93,7 @@ class SoftDeleteModelMixin(models.Model):
             )
 
             self.deleted_at = None
-            self.save()
+            self.save(update_fields=["deleted_at"])
 
             signals.post_undelete.send(
                 sender=self.__class__,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-kit"
-version = "1.17.6"
+version = "1.17.7"
 description = "DRF Toolkit"
 authors = ["Nilo Saude <tech@nilo.co>"]
 packages = [

--- a/test_app/signals.py
+++ b/test_app/signals.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
@@ -25,7 +27,7 @@ def harry_forever(sender, instance, **kwargs):
 
 @receiver(signals.pre_soft_delete, sender=models.Memory)
 def almost_erasing_memory(sender, instance, **kwargs):
-    instance.description += " [ERASED]"
+    warnings.warn("[ERASED]")
 
 
 @receiver(signals.post_soft_delete, sender=models.Memory)
@@ -35,7 +37,7 @@ def memory_has_been_erased(sender, instance, **kwargs):
 
 @receiver(signals.pre_undelete, sender=models.Memory)
 def almost_recovering_memory(sender, instance, **kwargs):
-    instance.description += " [RECOVERED]"
+    warnings.warn("[RECOVERED]")
 
 
 @receiver(signals.post_undelete, sender=models.Memory)

--- a/test_app/tests/tests_models/tests_soft_delete_models.py
+++ b/test_app/tests/tests_models/tests_soft_delete_models.py
@@ -12,10 +12,14 @@ from test_app.tests.tests_base import HogwartsTestMixin
 class TestSoftDeleteModel(HogwartsTestMixin, BaseApiTest):
     def test_delete_model(self):
         memory = MemoryFactory()
+        previous_description = memory.description
+        memory.description = "Any short description"
         self.assertIsNone(memory.deleted_at)
 
         memory.delete()
         memory.refresh_from_db()
+
+        self.assertEqual(memory.description, previous_description)
         self.assertIsNotNone(memory.deleted_at)
 
     def test_undelete_model(self):
@@ -23,8 +27,11 @@ class TestSoftDeleteModel(HogwartsTestMixin, BaseApiTest):
         memory.delete()
         memory.refresh_from_db()
 
+        previous_description = memory.description
+        memory.description = "Any short description"
         memory.undelete()
         memory.refresh_from_db()
+        self.assertEqual(memory.description, previous_description)
         self.assertIsNone(memory.deleted_at)
 
     def test_hard_delete_model(self):


### PR DESCRIPTION
In the present day, we're updating on database all modified attributes (in memory) on delete/undelete calls. This commit adds updated_fields into save() method calls to prevent that. So right now only deleted_at field will be updated

For instance
```
class MyModel(SoftDelete):
    title = models.CharField(max_length=50)

model = MyModel.objects.first()
model.title = "bla"
model.delete()

```