### PR TITLE
feat: support to format a datetime with custom value

### DIFF
--- a/drf_kit/serializers.py
+++ b/drf_kit/serializers.py
@@ -48,12 +48,12 @@ DATETIME_FORMAT = settings.REST_FRAMEWORK.get("DATETIME_FORMAT", "%Y-%m-%dT%H:%M
 DEFAULT_TIMEZONE = pytz.timezone(settings.TIME_ZONE)
 
 
-def as_str(value):
+def as_str(value, datetime_format: str = None):
     if value is None:
         return None
     if isinstance(value, datetime):
         value = assure_tz(value.astimezone(tz=DEFAULT_TIMEZONE))
-        return value.strftime(DATETIME_FORMAT)
+        return value.strftime(datetime_format or DATETIME_FORMAT)
     return str(value)
 
 

--- a/test_app/tests/tests_formatter.py
+++ b/test_app/tests/tests_formatter.py
@@ -43,6 +43,11 @@ class TestFormatAsStr(BaseApiTest):
         as_str = serializers.as_str(timezoned)
         self.assertEqual("1990-07-19T15:43:20Z", as_str)
 
+    def test_format_utc_custom_datetime_format(self):
+        timezoned = self.non_utc(datetime(1990, 7, 19, 15, 43, 20, 999999))
+        as_str = serializers.as_str(timezoned, "%Y-%m-%dT%H:%M:%S%z")
+        self.assertEqual("1990-07-19T15:43:20+0000", as_str)
+
 
 class TestAssureTimezone(BaseApiTest):
     def non_utc(self, dt):


### PR DESCRIPTION
The method `as_str` supports format datetime by app settings or default value. In most cases it's enought, alghout we have a case where the app' datetime format ends with Z and a single endpoint must returns the properly tz. The current method always returns "Z" even for timezone which are not in UTC