### PR TITLE
Fix filter_backends inside search action

### DIFF
--- a/drf_kit/views/viewsets.py
+++ b/drf_kit/views/viewsets.py
@@ -5,6 +5,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework_extensions.cache.mixins import BaseCacheResponseMixin
 
 from drf_kit import exceptions, filters
@@ -148,7 +149,11 @@ class MultiSerializerMixin:
 
 
 class SearchMixin:
-    @action(detail=False, methods=["post"], filter_backends=[filters.FilterInBodyBackend])
+    @action(
+        detail=False,
+        methods=["post"],
+        filter_backends=[filters.FilterInBodyBackend, *api_settings.DEFAULT_FILTER_BACKENDS],
+    )
     def search(self, request):
         return self.list(request)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-kit"
-version = "1.30.0"
+version = "1.30.1"
 description = "DRF Toolkit"
 authors = ["Nilo Saude <tech@nilo.co>"]
 packages = [

--- a/test_app/tests/tests_views/tests_filter_views.py
+++ b/test_app/tests/tests_views/tests_filter_views.py
@@ -50,3 +50,18 @@ class TestFilterView(HogwartsTestMixin, BaseApiTest):
         search = "potato"
         response = self.client.post(url, data=search, content_type="application/text")
         self.assertEqual(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, response.status_code)
+
+    def test_search_body_ordered(self):
+        teachers = []
+        for i in range(10, 20):
+            teachers.append(TeacherFactory(id=i, is_ghost=False, picture=None))
+        expected_teachers = [self.expected_teacher(teacher) for teacher in teachers]
+
+        for i in range(200, 210):
+            TeacherFactory(id=i, is_ghost=True, picture=None)  # noise
+
+        url = f"{self.url}/search?sort=id"
+        search = {"is_ghost": False}
+        response = self.client.post(url, data=search)
+
+        self.assertResponseList(expected_items=expected_teachers, response=response)


### PR DESCRIPTION
By incorporating the API's DEFAULT_FILTER_BACKENDS into `filter_backends` [search action], we refrain from altering the inherent behavior of the API's.