### PR TITLE
Fix `AllOfFilter`

### DIFF
--- a/drf_kit/filters.py
+++ b/drf_kit/filters.py
@@ -105,7 +105,9 @@ class AllOfFilter(MultipleChoiceFilter):
 
     def __init__(self, *args, **kwargs):
         if not kwargs.get("conjoined", True):
-            raise ValueError("AllOfFilter must be cojoined=True")
+            raise ValueError("AllOfFilter must be conjoined=True")
+        else:
+            kwargs.setdefault("conjoined", True)
         super().__init__(*args, **kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-kit"
-version = "1.32.0"
+version = "1.33.0"
 description = "DRF Toolkit"
 authors = ["Nilo Saude <tech@nilo.co>"]
 packages = [

--- a/test_app/filters.py
+++ b/test_app/filters.py
@@ -24,7 +24,7 @@ class WandFilterSet(filters.BaseFilterSet):
 
 
 class WizardFilterSet(filters.BaseFilterSet):
-    spell_name = filters.AllOfFilter(field_name="spell_casts__spell__name", conjoined=True)
+    spell_name = filters.AllOfFilter(field_name="spell_casts__spell__name")
 
     class Meta:
         model = models.Wizard

--- a/test_app/tests/tests_filter.py
+++ b/test_app/tests/tests_filter.py
@@ -244,5 +244,5 @@ class TestNullableFilterSet(HogwartsTestMixin, BaseApiTest):
 
 class TestAllOfFilter(BaseApiTest):
     def test_raise_exception_when_created_alloffilter_with_conjoined_false(self):
-        with self.assertRaisesMessage(ValueError, "AllOfFilter must be cojoined=True"):
+        with self.assertRaisesMessage(ValueError, "AllOfFilter must be conjoined=True"):
             filters.AllOfFilter(conjoined=False)


### PR DESCRIPTION
In the previous way, the value of `conjoined` was reset in the parent class [MultipleChoiceFilter](https://github.com/carltongibson/django-filter/blob/a2f7aba4e9aca9d6e9fc1f2ddc554daf87e8457e/django_filters/filters.py#L226), making it mandatory to provide the value as `True` when using the filter to work as expected

Ex.:
```python
spell_name = filters.AllOfFilter(field_name="spell_casts__spell__name", conjoined=True).
```
With this change, when omtting this declaration, the `__init__` will fill `True` in `conjoined`, and the exception continues to be raised when the passed value is `False`. Additionally, a typo error was fixed.