### PR TITLE
Fix search cache

### DIFF
--- a/drf_kit/cache.py
+++ b/drf_kit/cache.py
@@ -25,6 +25,18 @@ class CacheKeyConstructor(KeyConstructor):
 cache_key_constructor = CacheKeyConstructor()
 
 
+class BodyKeyBit(bits.AllArgsMixin, bits.KeyBitDictBase):
+    def get_source_dict(self, params, view_instance, view_method, request, args, kwargs):
+        return request.POST
+
+
+class BodyCacheKeyConstructor(CacheKeyConstructor):
+    body = BodyKeyBit()
+
+
+body_cache_key_constructor = BodyCacheKeyConstructor()
+
+
 class CacheResponse(decorators.CacheResponse):
     def process_cache_response(
         self,

--- a/drf_kit/views/viewsets.py
+++ b/drf_kit/views/viewsets.py
@@ -156,7 +156,15 @@ class SearchMixin:
         filter_backends=[filters.FilterInBodyBackend, *api_settings.DEFAULT_FILTER_BACKENDS],
     )
     def search(self, request):
-        return self.list(request)
+        queryset = self.filter_queryset(self.get_queryset())
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 class ModelViewSet(MultiSerializerMixin, viewsets.ModelViewSet):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-kit"
-version = "1.42.0"
+version = "1.42.1"
 description = "DRF Toolkit"
 authors = ["Nilo Saude <tech@nilo.co>"]
 packages = [

--- a/test_app/tests/tests_views/tests_filter_views.py
+++ b/test_app/tests/tests_views/tests_filter_views.py
@@ -70,6 +70,32 @@ class TestFilterView(HogwartsTestMixin, BaseApiTest):
 
         self.assertResponseList(expected_items=expected_teachers, response=response)
 
+    def test_search_miss_with_different_body(self):
+        url = f"{self.url}/search?name=Hermione"
+        data = {"age": 20, "is_half_blood": False}
+
+        response_json_miss = self.client.post(url, data=data)
+        self.assertEqual(status.HTTP_200_OK, response_json_miss.status_code)
+        self.assertEqual("MISS", response_json_miss["X-Cache"])
+
+        data = {"age": 25, "is_half_blood": True}
+
+        response_json_miss = self.client.post(url, data=data)
+        self.assertEqual(status.HTTP_200_OK, response_json_miss.status_code)
+        self.assertEqual("MISS", response_json_miss["X-Cache"])
+
+    def test_search_hit_with_same_body(self):
+        url = f"{self.url}/search?name=Hermione"
+        data = {"age": 20, "is_half_blood": False}
+
+        response_json_miss = self.client.post(url, data=data)
+        self.assertEqual(status.HTTP_200_OK, response_json_miss.status_code)
+        self.assertEqual("MISS", response_json_miss["X-Cache"])
+
+        response_json_hit = self.client.post(url, data=data)
+        self.assertEqual(status.HTTP_200_OK, response_json_hit.status_code)
+        self.assertEqual("HIT", response_json_hit["X-Cache"])
+
 
 class TestAnyOfFilter(BaseApiTest):
     def test_with_initial_value(self):

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -4,7 +4,6 @@ from rest_framework.response import Response
 
 from drf_kit.views import (
     BulkMixin,
-    CachedModelViewSet,
     ModelViewSet,
     NestedModelViewSet,
     NonDestructiveModelViewSet,
@@ -15,7 +14,7 @@ from drf_kit.views import (
     WriteOnlyModelViewSet,
     WriteOnlyNestedModelViewSet,
 )
-from drf_kit.views.viewsets import SearchMixin
+from drf_kit.views.viewsets import CachedSearchableModelViewSet
 from test_app import filters, models, serializers
 
 
@@ -32,7 +31,7 @@ class HouseViewSet(StatsViewMixin, ModelViewSet):
         )
 
 
-class TeacherViewSet(SearchMixin, CachedModelViewSet):
+class TeacherViewSet(CachedSearchableModelViewSet):
     queryset = models.Teacher.objects.all()
     serializer_class = serializers.TeacherSerializer
     filterset_class = filters.TeacherFilterSet


### PR DESCRIPTION
## Context
Cache policy does not take into account parameters in the request body. It should not, as this is an anti-pattern. However, `search` requests use a proxy to `list` method, which, contrary to `search`, supports cache.


## The issue
The problem is that the proxified request still use the arguments passed in the body, just like `search` request received it. And as cache does not look at body arguments, a `search` request that looked like this:

```
// example.com?potato=true
{
    "id": [10, 11, 12]
}
```

Will have a cache hit with the following request (which is completely different from the previous):
```
// example.com?potato=true
{
    "title": "Despicable me"
    "related_titles": ["A quiet place"]
}
```

## Solution
The solution has two layers:
1. Add bypass cache to subsequent cached methods in a View call stack. Only the view entry point (i.e. the method that maps to the endpoint hit by the client) will be able to both consume from cache and set values to it. The subsequent method calls ignore caching.
2. Create a new cache `key_func` for `search` requests. This `key_func` takes into account the body passed to the request, so calls for the same url, but with different bodies will now map to different keys, avoiding unexpected cache hits.