### PR TITLE
Add fallback to cache error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-kit"
-version = "1.42.4"
+version = "1.43.0"
 description = "DRF Toolkit"
 authors = ["Nilo Saude <tech@nilo.co>"]
 packages = [


### PR DESCRIPTION
More context on [this issue](https://github.com/flamingo-run/drf-toolkit/issues/59).

This change solves the problem of cache errors preventing the view action to be called. Besides, it adds the option of passing a function to be executed when cache fails.