### PR TITLE
AnyOfFilter shouldn't impose `distinct` by default unless joining on another table

### DIFF
--- a/drf_kit/filters.py
+++ b/drf_kit/filters.py
@@ -93,6 +93,10 @@ class _OpenChoiceField(MultipleChoiceField):
 class AnyOfFilter(MultipleChoiceFilter):
     field_class = _OpenChoiceField
 
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("distinct", None)
+        super().__init__(*args, **kwargs)
+
     def filter(self, qs, value):
         if not value:
             return qs
@@ -105,7 +109,10 @@ class AnyOfFilter(MultipleChoiceFilter):
             query_filter = Q(**predicate)
             qs = self.get_method(qs)(query_filter)
 
-        return qs.distinct() if self.distinct else qs
+        possibly_filtering_on_relationship = "__" in self.field_name
+        force_distinct = possibly_filtering_on_relationship if self.distinct is None else self.distinct
+
+        return qs.distinct() if force_distinct else qs
 
 
 class AllOfFilter(MultipleChoiceFilter):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-kit"
-version = "1.44.0"
+version = "1.45.0"
 description = "DRF Toolkit"
 authors = ["Nilo Saude <tech@nilo.co>"]
 packages = [

--- a/test_app/filters.py
+++ b/test_app/filters.py
@@ -25,6 +25,7 @@ class WandFilterSet(filters.BaseFilterSet):
 
 class WizardFilterSet(filters.BaseFilterSet):
     spell_name = filters.AllOfFilter(field_name="spell_casts__spell__name")
+    any_spell_name = filters.AnyOfFilter(field_name="spell_casts__spell__name")
 
     class Meta:
         model = models.Wizard

--- a/test_app/tests/tests_views/tests_filter_views.py
+++ b/test_app/tests/tests_views/tests_filter_views.py
@@ -138,6 +138,10 @@ class TestAllOfFilterView(HogwartsTestMixin, BaseApiTest):
         response = self.client.get(self.url, data={"spell_name": [self.spell_a.name, self.spell_b.name]})
         self.assertResponseItems(expected_items=[self.wizard_a], response=response)
 
+    def test_filter_multiple_spell_name_any_of_through_relationship(self):
+        response = self.client.get(self.url, data={"any_spell_name": [self.spell_a.name, self.spell_b.name]})
+        self.assertResponseItems(expected_items=[self.wizard_a, self.wizard_b], response=response)
+
     def test_filter_multiple_spell_name_disjointed_not_return_wizards(self):
         response = self.client.get(self.url, data={"spell_name": [self.spell_a.name, self.spell_noise.name]})
         self.assertResponseItems(expected_items=[], response=response)


### PR DESCRIPTION
## Context

Currently, `AnyOfFilter`, since it inherits from `MultipleChoiceFilter`, sets `distinct=True` by default on queries. This is for a good reason: when filtering on a field that may traverse relationships, rows may get duplicated as result.

## Issues

More often that not, `AnyOfFilter` is used to filter on the table own fields, in which case `distinct` is not necessary as rows won't duplicate by definition (they all have different primary keys 😅). It is unclear whether PostgreSQL can figure the same thing out on its own (I've done a simple test locally against a table and it seems it doesn't, at least for the case I tested). In case it can't, there are possible performance gains of not using distinct when filtering own table fields.

## Solution

`distinct` becomes a three-valued attribute for `AnyOfFilter`:

- `True`: uses distinct()
- `False`: doesn't use distinct()
- `None` (the default): infer based on the `field_name`: if it contains a navigation (identified by the presence of a `__`), use distinct.

Note: lookups are also double underscored and will become "false positives" (triggering distinct when not needed), but this matches the current behavior (which triggers distinct all the time) and is not a regression.