### PR TITLE
Allow custom key_func in search action

### DIFF
--- a/drf_kit/views/viewsets.py
+++ b/drf_kit/views/viewsets.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.db import IntegrityError
 from django.db.models import Model
 from rest_framework import status, viewsets
@@ -208,7 +209,7 @@ class CachedModelViewSet(CacheResponseMixin, ModelViewSet):
 # and they are good to go.
 class CachedSearchableMixin(SearchMixin, CacheResponseMixin):
     @search_action
-    @cache_response(key_func=body_cache_key_constructor)
+    @cache_response(key_func=getattr(settings, "DEFAULT_BODY_CACHE_KEY_FUNC", None) or body_cache_key_constructor)
     def search(self, request, *args, **kwargs):
         return super().search(request, *args, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "drf-kit"
-version = "1.47.0"
+version = "1.48.0"
 description = "DRF Toolkit"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
# Context
The default django rest framework cache in search action was being overwritten by the `body_cache_key_constructor`. In order to include custom cache behavior for this action in the django app level, this change proposes to enable cache customization based on the django settings `DEFAULT_BODY_CACHE_KEY_FUNC`.