### PR TITLE
Add settings configuration with body-based cache key function

### DIFF
--- a/drf_kit/settings.py
+++ b/drf_kit/settings.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from rest_framework.settings import APISettings
+
+USER_SETTINGS = getattr(settings, "REST_FRAMEWORK_TOOLKIT", None)
+
+DEFAULTS = {
+    "DEFAULT_BODY_CACHE_KEY_FUNC": "drf_kit.cache.body_cache_key_constructor",
+}
+
+IMPORT_STRINGS = [
+    "DEFAULT_BODY_CACHE_KEY_FUNC",
+]
+
+toolkit_api_settings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)

--- a/drf_kit/views/viewsets.py
+++ b/drf_kit/views/viewsets.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.conf import settings
 from django.db import IntegrityError
 from django.db.models import Model
 from rest_framework import status, viewsets
@@ -11,8 +10,9 @@ from rest_framework.settings import api_settings
 from rest_framework_extensions.cache.mixins import BaseCacheResponseMixin
 
 from drf_kit import exceptions, filters
-from drf_kit.cache import body_cache_key_constructor, cache_response
+from drf_kit.cache import cache_response
 from drf_kit.exceptions import ConflictException, DuplicatedRecord, ExclusionDuplicatedRecord
+from drf_kit.settings import toolkit_api_settings
 
 logger = logging.getLogger(__name__)
 
@@ -209,7 +209,7 @@ class CachedModelViewSet(CacheResponseMixin, ModelViewSet):
 # and they are good to go.
 class CachedSearchableMixin(SearchMixin, CacheResponseMixin):
     @search_action
-    @cache_response(key_func=getattr(settings, "DEFAULT_BODY_CACHE_KEY_FUNC", None) or body_cache_key_constructor)
+    @cache_response(key_func=toolkit_api_settings.DEFAULT_BODY_CACHE_KEY_FUNC)
     def search(self, request, *args, **kwargs):
         return super().search(request, *args, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "drf-kit"
-version = "1.48.0"
+version = "1.49.0"
 description = "DRF Toolkit"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
PR #64 introduced `DEFAULT_BODY_CACHE_KEY_FUNCTION` as a setting, but it was proven a bit hard to use, as you couldn't refer to the function using the dotted import name and had to provide the key function per se. This required some sort of lazy import wrapper to be used in settings.py, which is cumbersome.

This PR refactors this setting so it works just like the ones defined by drf-extensions under `REST_FRAMEWORK_EXTENSIONS`