### PR TITLE
fix: update CheckConstraint to use condition= for Django 6 compatibility

### DIFF
--- a/drf_kit/exceptions.py
+++ b/drf_kit/exceptions.py
@@ -119,7 +119,7 @@ class InvalidRecord(DatabaseIntegrityError):
     def constraint_check(self) -> Q | None:
         for constraint in self.model._meta.constraints:
             if constraint.name == self.outcome:
-                return constraint.check
+                return constraint.condition
         return None
 
     def _parse_psql(self):

--- a/drf_kit/models/availability_models.py
+++ b/drf_kit/models/availability_models.py
@@ -33,7 +33,7 @@ class AvailabilityModelMixin(models.Model):
         ]
         constraints = [
             models.CheckConstraint(
-                check=models.Q(starts_at__lte=models.F("ends_at")),
+                condition=models.Q(starts_at__lte=models.F("ends_at")),
                 name="%(class)s_invalid_date_range",
             ),
         ]

--- a/test_app/migrations/0004_newspaper_roomofrequirement_and_more.py
+++ b/test_app/migrations/0004_newspaper_roomofrequirement_and_more.py
@@ -83,7 +83,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="newspaper",
             constraint=models.CheckConstraint(
-                check=models.Q(("starts_at__lte", models.F("ends_at"))),
+                condition=models.Q(("starts_at__lte", models.F("ends_at"))),
                 name="newspaper_invalid_date_range",
             ),
         ),
@@ -102,7 +102,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="roomofrequirement",
             constraint=models.CheckConstraint(
-                check=models.Q(("starts_at__lte", models.F("ends_at"))),
+                condition=models.Q(("starts_at__lte", models.F("ends_at"))),
                 name="roomofrequirement_invalid_date_range",
             ),
         ),

--- a/test_app/migrations/0007_beast_beast_test_app_be_updated_682cc9_idx_and_more.py
+++ b/test_app/migrations/0007_beast_beast_test_app_be_updated_682cc9_idx_and_more.py
@@ -43,6 +43,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name="beast",
-            constraint=models.CheckConstraint(check=models.Q(("age__gte", 0)), name="minimum-beast-age"),
+            constraint=models.CheckConstraint(condition=models.Q(("age__gte", 0)), name="minimum-beast-age"),
         ),
     ]

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -270,7 +270,7 @@ class Beast(SoftDeleteModel):
     class Meta(BaseModel.Meta):
         constraints = [
             models.UniqueConstraint(fields=["name", "age"], name="single-beast-per-year"),
-            models.CheckConstraint(check=models.Q(age__gte=0), name="minimum-beast-age"),
+            models.CheckConstraint(condition=models.Q(age__gte=0), name="minimum-beast-age"),
         ]
 
 


### PR DESCRIPTION
## Summary
- Updated `CheckConstraint` to use `condition=` parameter instead of deprecated `check=` parameter
- This change is required for Django 6.0 compatibility, where the `check=` parameter was removed
- Updated both model definitions and existing migrations

## Background
Django 4.1 deprecated the `check=` parameter in favor of `condition=` for consistency with other constraint classes. Django 6.0 removed the deprecated parameter entirely.

## Files Changed
- `drf_kit/models/availability_models.py` - Main library constraint definition
- `test_app/models.py` - Test model constraint
- `test_app/migrations/0004_newspaper_roomofrequirement_and_more.py` - Historical migration
- `test_app/migrations/0007_beast_beast_test_app_be_updated_682cc9_idx_and_more.py` - Historical migration

## Test plan
- [ ] Verify tests pass on Django 5.x (backward compatible)
- [ ] Verify tests pass on Django 6.0

🤖 Generated with [Claude Code](https://claude.ai/code)